### PR TITLE
Add option to dump with "INSERT IGNORE"

### DIFF
--- a/src/common/common.go
+++ b/src/common/common.go
@@ -37,6 +37,7 @@ type Args struct {
 	Allbytes        uint64
 	Allrows         uint64
 	OverwriteTables bool
+	InsertIgnore    bool
 
 	// Interval in millisecond.
 	IntervalMs int

--- a/src/common/dumper.go
+++ b/src/common/dumper.go
@@ -63,6 +63,12 @@ func dumpTable(log *xlog.Log, conn *Connection, args *Args, table string) {
 	chunkbytes := 0
 	rows := make([]string, 0, 256)
 	inserts := make([]string, 0, 256)
+
+	insertStatement := "INSERT"
+	if args.InsertIgnore {
+		insertStatement += " IGNORE"
+	}
+
 	for cursor.Next() {
 		row, err := cursor.RowValues()
 		AssertNil(err)
@@ -92,7 +98,7 @@ func dumpTable(log *xlog.Log, conn *Connection, args *Args, table string) {
 		atomic.AddUint64(&args.Allrows, 1)
 
 		if stmtsize >= args.StmtSize {
-			insertone := fmt.Sprintf("INSERT INTO `%s`(%s) VALUES\n%s", table, strings.Join(fields, ","), strings.Join(rows, ",\n"))
+			insertone := fmt.Sprintf("%s INTO `%s`(%s) VALUES\n%s", insertStatement, table, strings.Join(fields, ","), strings.Join(rows, ",\n"))
 			inserts = append(inserts, insertone)
 			rows = rows[:0]
 			stmtsize = 0
@@ -111,7 +117,7 @@ func dumpTable(log *xlog.Log, conn *Connection, args *Args, table string) {
 	}
 	if chunkbytes > 0 {
 		if len(rows) > 0 {
-			insertone := fmt.Sprintf("INSERT INTO `%s`(%s) VALUES\n%s", table, strings.Join(fields, ","), strings.Join(rows, ",\n"))
+			insertone := fmt.Sprintf("%s INTO `%s`(%s) VALUES\n%s", insertStatement, table, strings.Join(fields, ","), strings.Join(rows, ",\n"))
 			inserts = append(inserts, insertone)
 		}
 

--- a/src/mydumper/main.go
+++ b/src/mydumper/main.go
@@ -21,6 +21,7 @@ import (
 var (
 	flagChunksize, flagThreads, flagPort, flagStmtSize                          int
 	flagUser, flagPasswd, flagHost, flagDb, flagTable, flagDir, flagSessionVars string
+	flagInsertIgnore                                                            bool
 
 	log = xlog.NewStdLog(xlog.Level(xlog.INFO))
 )
@@ -37,6 +38,8 @@ func init() {
 	flag.IntVar(&flagThreads, "t", 16, "Number of threads to use")
 	flag.IntVar(&flagStmtSize, "s", 1000000, "Attempted size of INSERT statement in bytes")
 	flag.StringVar(&flagSessionVars, "vars", "", "Session variables")
+	flag.BoolVar(&flagInsertIgnore, "ignore", false, "Use INSERT IGNORE instead of simple INSERT")
+
 }
 
 func usage() {
@@ -70,6 +73,7 @@ func main() {
 		StmtSize:      flagStmtSize,
 		IntervalMs:    10 * 1000,
 		SessionVars:   flagSessionVars,
+		InsertIgnore:  flagInsertIgnore,
 	}
 
 	common.Dumper(log, args)


### PR DESCRIPTION
Add an option, similar to the one available in mydumper, to dump the content using `INSERT IGNORE` instead of `INSERT`.