### PR TITLE
Allow regex to specify databases to dump

### DIFF
--- a/conf/mydumper.ini.sample
+++ b/conf/mydumper.ini.sample
@@ -17,6 +17,13 @@ chunksize = 128
 # vars= "xx=xx;xx=xx;"
 vars= ""
 
+# Use this to use regexp to control what databases to export. These are optional
+[database]
+# regexp = ^(mysql|sys|information_schema|performance_schema)$
+# As the used regexp lib does not allow for lookarounds, you may use this to invert the whole regexp
+# This option should be refactored as soon as a GPLv3 compliant go-pcre lib is found
+# invert_regexp = on
+
 # Use this to restrict exported data. These are optional
 [where]
 # sample_table1 = created_at >= DATE_SUB(NOW(), INTERVAL 7 DAY)

--- a/src/cmd/config.go
+++ b/src/cmd/config.go
@@ -84,10 +84,18 @@ func parseDumperConfig(file string) (*common.Args, error) {
 		}
 	}
 
+	database_regexp, _ := cfg.GetString("database", "regexp")
+	database_invert_regexp, err := cfg.GetBool("database", "invert_regexp")
+	if err != nil {
+		database_invert_regexp = false
+	}
+
 	args.Address = fmt.Sprintf("%s:%d", host, port)
 	args.User = user
 	args.Password = password
 	args.Database = database
+	args.DatabaseRegexp = database_regexp
+	args.DatabaseInvertRegexp = database_invert_regexp
 	args.Table = table
 	args.Outdir = outdir
 	args.ChunksizeInMB = chunksizemb

--- a/src/common/common.go
+++ b/src/common/common.go
@@ -19,26 +19,28 @@ import (
 
 // Args tuple.
 type Args struct {
-	User            string
-	Password        string
-	Address         string
-	ToUser          string
-	ToPassword      string
-	ToAddress       string
-	ToDatabase      string
-	ToEngine        string
-	Database        string
-	Table           string
-	Outdir          string
-	SessionVars     string
-	Threads         int
-	ChunksizeInMB   int
-	StmtSize        int
-	Allbytes        uint64
-	Allrows         uint64
-	OverwriteTables bool
-	Wheres          map[string]string
-	Selects         map[string]map[string]string
+	User                 string
+	Password             string
+	Address              string
+	ToUser               string
+	ToPassword           string
+	ToAddress            string
+	ToDatabase           string
+	ToEngine             string
+	Database             string
+	DatabaseRegexp       string
+	DatabaseInvertRegexp bool
+	Table                string
+	Outdir               string
+	SessionVars          string
+	Threads              int
+	ChunksizeInMB        int
+	StmtSize             int
+	Allbytes             uint64
+	Allrows              uint64
+	OverwriteTables      bool
+	Wheres               map[string]string
+	Selects              map[string]map[string]string
 
 	// Interval in millisecond.
 	IntervalMs int

--- a/src/common/dumper_test.go
+++ b/src/common/dumper_test.go
@@ -459,3 +459,511 @@ func TestDumperMultiple(t *testing.T) {
 	want_test2 := strings.Contains(string(dat_test2), `(1337)`)
 	assert.True(t, want_test2)
 }
+
+func TestDumperSimpleRegexp(t *testing.T) {
+	log := xlog.NewStdLog(xlog.Level(xlog.INFO))
+	fakedbs := driver.NewTestHandler(log)
+	server, err := driver.MockMysqlServer(log, fakedbs)
+	assert.Nil(t, err)
+	defer server.Close()
+	address := server.Addr()
+
+	selectResult1 := &sqltypes.Result{
+		Fields: []*querypb.Field{
+			{
+				Name: "id",
+				Type: querypb.Type_INT32,
+			},
+			{
+				Name: "name",
+				Type: querypb.Type_VARCHAR,
+			},
+			{
+				Name: "namei1",
+				Type: querypb.Type_VARCHAR,
+			},
+			{
+				Name: "null",
+				Type: querypb.Type_NULL_TYPE,
+			},
+			{
+				Name: "decimal",
+				Type: querypb.Type_DECIMAL,
+			},
+			{
+				Name: "datetime",
+				Type: querypb.Type_DATETIME,
+			},
+		},
+		Rows: make([][]sqltypes.Value, 0, 256)}
+
+	for i := 0; i < 201710; i++ {
+		row := []sqltypes.Value{
+			sqltypes.MakeTrusted(querypb.Type_INT32, []byte("11")),
+			sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("11\"xx\"")),
+			sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("")),
+			sqltypes.MakeTrusted(querypb.Type_NULL_TYPE, nil),
+			sqltypes.MakeTrusted(querypb.Type_DECIMAL, []byte("210.01")),
+			sqltypes.NULL,
+		}
+		selectResult1.Rows = append(selectResult1.Rows, row)
+	}
+
+	selectResult2 := &sqltypes.Result{
+		Fields: []*querypb.Field{
+			{
+				Name: "id",
+				Type: querypb.Type_INT32,
+			},
+		},
+		Rows: make([][]sqltypes.Value, 0, 256)}
+
+	for i := 0; i < 201710; i++ {
+		row := []sqltypes.Value{
+			sqltypes.MakeTrusted(querypb.Type_INT32, []byte("1337")),
+		}
+		selectResult2.Rows = append(selectResult2.Rows, row)
+	}
+
+	schemaResult := &sqltypes.Result{
+		Fields: []*querypb.Field{
+			{
+				Name: "Table",
+				Type: querypb.Type_VARCHAR,
+			},
+			{
+				Name: "Create Table",
+				Type: querypb.Type_VARCHAR,
+			},
+		},
+		Rows: [][]sqltypes.Value{
+			{
+				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("t1")),
+				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("CREATE TABLE `t1-05-11` (`a` int(11) DEFAULT NULL,`b` varchar(100) DEFAULT NULL) ENGINE=InnoDB")),
+			},
+		}}
+
+	tablesResult := &sqltypes.Result{
+		Fields: []*querypb.Field{
+			{
+				Name: "Tables_in_test",
+				Type: querypb.Type_VARCHAR,
+			},
+		},
+		Rows: [][]sqltypes.Value{
+			{
+				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("t1-05-11")),
+			},
+			{
+				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("t2-05-11")),
+			},
+		}}
+
+	databasesResult := &sqltypes.Result{
+		Fields: []*querypb.Field{
+			{
+				Name: "Databases_in_database",
+				Type: querypb.Type_VARCHAR,
+			},
+		},
+		Rows: [][]sqltypes.Value{
+			{
+				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("test1")),
+			},
+			{
+				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("test2")),
+			},
+			{
+				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("test3")),
+			},
+			{
+				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("test4")),
+			},
+			{
+				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("test5")),
+			},
+		}}
+
+	// fakedbs.
+	{
+		fakedbs.AddQueryPattern("show databases", databasesResult)
+		fakedbs.AddQueryPattern("use .*", &sqltypes.Result{})
+		fakedbs.AddQueryPattern("show create table .*", schemaResult)
+		fakedbs.AddQueryPattern("show tables from .*", tablesResult)
+		fakedbs.AddQueryPattern("select .* from `test1`.*", selectResult1)
+		fakedbs.AddQueryPattern("select .* from `test2`.*", selectResult2)
+		fakedbs.AddQueryPattern("set .*", &sqltypes.Result{})
+	}
+
+	args := &Args{
+		DatabaseRegexp: "(test1|test2)",
+		Outdir:         "/tmp/dumpertest",
+		User:           "mock",
+		Password:       "mock",
+		Address:        address,
+		ChunksizeInMB:  1,
+		Threads:        16,
+		StmtSize:       10000,
+		IntervalMs:     500,
+		SessionVars:    "SET @@radon_streaming_fetch='ON', @@xx=1",
+	}
+
+	os.RemoveAll(args.Outdir)
+	if _, err := os.Stat(args.Outdir); os.IsNotExist(err) {
+		x := os.MkdirAll(args.Outdir, 0777)
+		AssertNil(x)
+	}
+
+	// Dumper.
+	{
+		Dumper(log, args)
+	}
+	dat_test1, err_test1 := ioutil.ReadFile(args.Outdir + "/test1.t1-05-11.00001.sql")
+	assert.Nil(t, err_test1)
+	want_test1 := strings.Contains(string(dat_test1), `(11,"11\"xx\"","",NULL,210.01,NULL)`)
+	assert.True(t, want_test1)
+	dat_test2, err_test2 := ioutil.ReadFile(args.Outdir + "/test2.t1-05-11.00001.sql")
+	assert.Nil(t, err_test2)
+	want_test2 := strings.Contains(string(dat_test2), `(1337)`)
+	assert.True(t, want_test2)
+}
+
+func TestDumperComplexRegexp(t *testing.T) {
+	log := xlog.NewStdLog(xlog.Level(xlog.INFO))
+	fakedbs := driver.NewTestHandler(log)
+	server, err := driver.MockMysqlServer(log, fakedbs)
+	assert.Nil(t, err)
+	defer server.Close()
+	address := server.Addr()
+
+	selectResult1 := &sqltypes.Result{
+		Fields: []*querypb.Field{
+			{
+				Name: "id",
+				Type: querypb.Type_INT32,
+			},
+			{
+				Name: "name",
+				Type: querypb.Type_VARCHAR,
+			},
+			{
+				Name: "namei1",
+				Type: querypb.Type_VARCHAR,
+			},
+			{
+				Name: "null",
+				Type: querypb.Type_NULL_TYPE,
+			},
+			{
+				Name: "decimal",
+				Type: querypb.Type_DECIMAL,
+			},
+			{
+				Name: "datetime",
+				Type: querypb.Type_DATETIME,
+			},
+		},
+		Rows: make([][]sqltypes.Value, 0, 256)}
+
+	for i := 0; i < 201710; i++ {
+		row := []sqltypes.Value{
+			sqltypes.MakeTrusted(querypb.Type_INT32, []byte("11")),
+			sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("11\"xx\"")),
+			sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("")),
+			sqltypes.MakeTrusted(querypb.Type_NULL_TYPE, nil),
+			sqltypes.MakeTrusted(querypb.Type_DECIMAL, []byte("210.01")),
+			sqltypes.NULL,
+		}
+		selectResult1.Rows = append(selectResult1.Rows, row)
+	}
+
+	selectResult2 := &sqltypes.Result{
+		Fields: []*querypb.Field{
+			{
+				Name: "id",
+				Type: querypb.Type_INT32,
+			},
+		},
+		Rows: make([][]sqltypes.Value, 0, 256)}
+
+	for i := 0; i < 201710; i++ {
+		row := []sqltypes.Value{
+			sqltypes.MakeTrusted(querypb.Type_INT32, []byte("1337")),
+		}
+		selectResult2.Rows = append(selectResult2.Rows, row)
+	}
+
+	schemaResult := &sqltypes.Result{
+		Fields: []*querypb.Field{
+			{
+				Name: "Table",
+				Type: querypb.Type_VARCHAR,
+			},
+			{
+				Name: "Create Table",
+				Type: querypb.Type_VARCHAR,
+			},
+		},
+		Rows: [][]sqltypes.Value{
+			{
+				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("t1")),
+				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("CREATE TABLE `t1-05-11` (`a` int(11) DEFAULT NULL,`b` varchar(100) DEFAULT NULL) ENGINE=InnoDB")),
+			},
+		}}
+
+	tablesResult := &sqltypes.Result{
+		Fields: []*querypb.Field{
+			{
+				Name: "Tables_in_test",
+				Type: querypb.Type_VARCHAR,
+			},
+		},
+		Rows: [][]sqltypes.Value{
+			{
+				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("t1-05-11")),
+			},
+			{
+				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("t2-05-11")),
+			},
+		}}
+
+	databasesResult := &sqltypes.Result{
+		Fields: []*querypb.Field{
+			{
+				Name: "Databases_in_database",
+				Type: querypb.Type_VARCHAR,
+			},
+		},
+		Rows: [][]sqltypes.Value{
+			{
+				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("test1")),
+			},
+			{
+				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("test2")),
+			},
+			{
+				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("foo1")),
+			},
+			{
+				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("bar2")),
+			},
+			{
+				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("test5")),
+			},
+		}}
+
+	// fakedbs.
+	{
+		fakedbs.AddQueryPattern("show databases", databasesResult)
+		fakedbs.AddQueryPattern("use .*", &sqltypes.Result{})
+		fakedbs.AddQueryPattern("show create table .*", schemaResult)
+		fakedbs.AddQueryPattern("show tables from .*", tablesResult)
+		fakedbs.AddQueryPattern("select .* from `test1`.*", selectResult1)
+		fakedbs.AddQueryPattern("select .* from `test2`.*", selectResult2)
+		fakedbs.AddQueryPattern("set .*", &sqltypes.Result{})
+	}
+
+	args := &Args{
+		DatabaseRegexp: "^[ets]+?[0-2]$",
+		Outdir:         "/tmp/dumpertest",
+		User:           "mock",
+		Password:       "mock",
+		Address:        address,
+		ChunksizeInMB:  1,
+		Threads:        16,
+		StmtSize:       10000,
+		IntervalMs:     500,
+		SessionVars:    "SET @@radon_streaming_fetch='ON', @@xx=1",
+	}
+
+	os.RemoveAll(args.Outdir)
+	if _, err := os.Stat(args.Outdir); os.IsNotExist(err) {
+		x := os.MkdirAll(args.Outdir, 0777)
+		AssertNil(x)
+	}
+
+	// Dumper.
+	{
+		Dumper(log, args)
+	}
+	dat_test1, err_test1 := ioutil.ReadFile(args.Outdir + "/test1.t1-05-11.00001.sql")
+	assert.Nil(t, err_test1)
+	want_test1 := strings.Contains(string(dat_test1), `(11,"11\"xx\"","",NULL,210.01,NULL)`)
+	assert.True(t, want_test1)
+	dat_test2, err_test2 := ioutil.ReadFile(args.Outdir + "/test2.t1-05-11.00001.sql")
+	assert.Nil(t, err_test2)
+	want_test2 := strings.Contains(string(dat_test2), `(1337)`)
+	assert.True(t, want_test2)
+}
+
+func TestDumperInvertMatch(t *testing.T) {
+	log := xlog.NewStdLog(xlog.Level(xlog.INFO))
+	fakedbs := driver.NewTestHandler(log)
+	server, err := driver.MockMysqlServer(log, fakedbs)
+	assert.Nil(t, err)
+	defer server.Close()
+	address := server.Addr()
+
+	selectResult1 := &sqltypes.Result{
+		Fields: []*querypb.Field{
+			{
+				Name: "id",
+				Type: querypb.Type_INT32,
+			},
+			{
+				Name: "name",
+				Type: querypb.Type_VARCHAR,
+			},
+			{
+				Name: "namei1",
+				Type: querypb.Type_VARCHAR,
+			},
+			{
+				Name: "null",
+				Type: querypb.Type_NULL_TYPE,
+			},
+			{
+				Name: "decimal",
+				Type: querypb.Type_DECIMAL,
+			},
+			{
+				Name: "datetime",
+				Type: querypb.Type_DATETIME,
+			},
+		},
+		Rows: make([][]sqltypes.Value, 0, 256)}
+
+	for i := 0; i < 201710; i++ {
+		row := []sqltypes.Value{
+			sqltypes.MakeTrusted(querypb.Type_INT32, []byte("11")),
+			sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("11\"xx\"")),
+			sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("")),
+			sqltypes.MakeTrusted(querypb.Type_NULL_TYPE, nil),
+			sqltypes.MakeTrusted(querypb.Type_DECIMAL, []byte("210.01")),
+			sqltypes.NULL,
+		}
+		selectResult1.Rows = append(selectResult1.Rows, row)
+	}
+
+	selectResult2 := &sqltypes.Result{
+		Fields: []*querypb.Field{
+			{
+				Name: "id",
+				Type: querypb.Type_INT32,
+			},
+		},
+		Rows: make([][]sqltypes.Value, 0, 256)}
+
+	for i := 0; i < 201710; i++ {
+		row := []sqltypes.Value{
+			sqltypes.MakeTrusted(querypb.Type_INT32, []byte("1337")),
+		}
+		selectResult2.Rows = append(selectResult2.Rows, row)
+	}
+
+	schemaResult := &sqltypes.Result{
+		Fields: []*querypb.Field{
+			{
+				Name: "Table",
+				Type: querypb.Type_VARCHAR,
+			},
+			{
+				Name: "Create Table",
+				Type: querypb.Type_VARCHAR,
+			},
+		},
+		Rows: [][]sqltypes.Value{
+			{
+				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("t1")),
+				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("CREATE TABLE `t1-05-11` (`a` int(11) DEFAULT NULL,`b` varchar(100) DEFAULT NULL) ENGINE=InnoDB")),
+			},
+		}}
+
+	tablesResult := &sqltypes.Result{
+		Fields: []*querypb.Field{
+			{
+				Name: "Tables_in_test",
+				Type: querypb.Type_VARCHAR,
+			},
+		},
+		Rows: [][]sqltypes.Value{
+			{
+				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("t1-05-11")),
+			},
+			{
+				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("t2-05-11")),
+			},
+		}}
+
+	databasesResult := &sqltypes.Result{
+		Fields: []*querypb.Field{
+			{
+				Name: "Databases_in_database",
+				Type: querypb.Type_VARCHAR,
+			},
+		},
+		Rows: [][]sqltypes.Value{
+			{
+				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("test1")),
+			},
+			{
+				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("test2")),
+			},
+			{
+				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("mysql")),
+			},
+			{
+				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("sys")),
+			},
+			{
+				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("information_schema")),
+			},
+			{
+				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("performance_schema")),
+			},
+		}}
+
+	// fakedbs.
+	{
+		fakedbs.AddQueryPattern("show databases", databasesResult)
+		fakedbs.AddQueryPattern("use .*", &sqltypes.Result{})
+		fakedbs.AddQueryPattern("show create table .*", schemaResult)
+		fakedbs.AddQueryPattern("show tables from .*", tablesResult)
+		fakedbs.AddQueryPattern("select .* from `test1`.*", selectResult1)
+		fakedbs.AddQueryPattern("select .* from `test2`.*", selectResult2)
+		fakedbs.AddQueryPattern("set .*", &sqltypes.Result{})
+	}
+
+	args := &Args{
+		DatabaseRegexp:       "^(mysql|sys|information_schema|performance_schema)$",
+		DatabaseInvertRegexp: true,
+		Outdir:               "/tmp/dumpertest",
+		User:                 "mock",
+		Password:             "mock",
+		Address:              address,
+		ChunksizeInMB:        1,
+		Threads:              16,
+		StmtSize:             10000,
+		IntervalMs:           500,
+		SessionVars:          "SET @@radon_streaming_fetch='ON', @@xx=1",
+	}
+
+	os.RemoveAll(args.Outdir)
+	if _, err := os.Stat(args.Outdir); os.IsNotExist(err) {
+		x := os.MkdirAll(args.Outdir, 0777)
+		AssertNil(x)
+	}
+
+	// Dumper.
+	{
+		Dumper(log, args)
+	}
+	dat_test1, err_test1 := ioutil.ReadFile(args.Outdir + "/test1.t1-05-11.00001.sql")
+	assert.Nil(t, err_test1)
+	want_test1 := strings.Contains(string(dat_test1), `(11,"11\"xx\"","",NULL,210.01,NULL)`)
+	assert.True(t, want_test1)
+	dat_test2, err_test2 := ioutil.ReadFile(args.Outdir + "/test2.t1-05-11.00001.sql")
+	assert.Nil(t, err_test2)
+	want_test2 := strings.Contains(string(dat_test2), `(1337)`)
+	assert.True(t, want_test2)
+}


### PR DESCRIPTION
Closes #26 

- [x] Fully implement regexp support for databases
- [x] Make it possible to invert the match (because no PCRE lookarounds support)
- [x] Tests